### PR TITLE
skip requireing akashic-commons/node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jasmine-terminal-reporter": "~0.9.1",
     "mdast": "~2.0.0",
     "mdast-lint": "~1.1.1",
-    "mock-fs": "3.12.1",
+    "mock-fs": "~4.2.0",
     "tslint": "~3.7.4",
     "typescript": "^1.7.5",
     "typings": "1.0.4"

--- a/src/NodeModules.ts
+++ b/src/NodeModules.ts
@@ -66,14 +66,14 @@ export module NodeModules {
 						const detectedModuleName = path.basename(path.dirname(filePath));
 
 						const msg = "Reference to '" + detectedModuleName
-							+ "' is detected and skipped to listing."
+							+ "' is detected and skipped listing."
 							+ " Akashic content cannot depend on core modules of Node.js."
 							+ " You should build your game runnable without '" + detectedModuleName + "'.";
 						logger.warn(msg);
 						return;
 					}
 					var msg = "Unsupported module found in " + JSON.stringify(modules)
-												+ ". Skipped to listing '" + filePath
+												+ ". Skipped listing '" + filePath
 												+ "' that cannot be dealt with. (This may be a core module of Node.js)";
 					reject(new Error(msg));
 					return;

--- a/src/NodeModules.ts
+++ b/src/NodeModules.ts
@@ -7,11 +7,10 @@ import { ConsoleLogger } from "./ConsoleLogger";
 import { StringStream } from "./StringStream";
 
 export module NodeModules {
-	export function listModuleFiles(basepath: string, modules: string|string[], logger?: Logger): Promise<string[]> {
-		const _logger = logger || new ConsoleLogger();
+	export function listModuleFiles(basepath: string, modules: string|string[], logger: Logger = new ConsoleLogger()): Promise<string[]> {
 		if (modules.length === 0) return Promise.resolve([]);
 		return Promise.resolve()
-			.then(() => NodeModules._listScriptFiles(basepath, modules, _logger))
+			.then(() => NodeModules._listScriptFiles(basepath, modules, logger))
 			.then((paths) => paths.concat(NodeModules._listPackageJsonsFromScriptsPath(basepath, paths)));
 	}
 
@@ -67,9 +66,9 @@ export module NodeModules {
 						const detectedModuleName = path.basename(path.dirname(filePath));
 
 						const msg = "Reference to '" + detectedModuleName
-							+ "' is detected, and Skipped to listing."
-							+ " Akashic content should not depend on core module of Node.js."
-							+ " Game Developers should build your game runnable without reference to '" + detectedModuleName + "'.";
+							+ "' is detected and skipped to listing."
+							+ " Akashic content cannot depend on core modules of Node.js."
+							+ " You should build your game runnable without '" + detectedModuleName + "'.";
 						logger.warn(msg);
 						return;
 					}

--- a/src/NodeModules.ts
+++ b/src/NodeModules.ts
@@ -48,10 +48,25 @@ export module NodeModules {
 		return new Promise<string[]>((resolve, reject) => {
 			var filePaths: string[] = [];
 			b.on("dep", (row: any) => {
+				// console.log("row: " + row.file, Object.keys(row));
 				if (row.file === dummyRootName)
 					return;
+
+				const rawFilePath = Util.makeUnixPath(row.file);
+				// const ignorefilePath = Util.makeUnixPath("akashic-cli-commons/node_modules/process/browser.js");
+				const ignoreModulePaths = [
+					"akashic-cli-commons/node_modules/"
+					].map((modulePath) => Util.makeUnixPath(modulePath));
+				// console.log(rawFilePath, ignorefilePath);
+				// if (rawFilePath.includes(ignorefilePath)) return;
+				if (ignoreModulePaths.find((modulePath) => rawFilePath.includes(modulePath))) {
+					return;
+				}
+
 				var filePath = Util.makeUnixPath(path.relative(basepath, row.file));
 				if (/^\.\.\//.test(filePath)) {
+					console.log("[BAD]", filePath);
+					//return ;
 					var msg = "Unsupported module found in " + JSON.stringify(modules)
 												+ ". Skipped to listing '" + filePath
 												+ "' that cannot be dealt with. (This may be a core module of Node.js)";
@@ -61,6 +76,7 @@ export module NodeModules {
 				filePaths.push(filePath);
 			});
 			b.bundle((err: any) => {
+				console.log("bundle err", !!err);
 				err ? reject(err) : resolve(filePaths);
 			});
 		});

--- a/src/NodeModules.ts
+++ b/src/NodeModules.ts
@@ -48,25 +48,17 @@ export module NodeModules {
 		return new Promise<string[]>((resolve, reject) => {
 			var filePaths: string[] = [];
 			b.on("dep", (row: any) => {
-				// console.log("row: " + row.file, Object.keys(row));
 				if (row.file === dummyRootName)
 					return;
 
 				const rawFilePath = Util.makeUnixPath(row.file);
-				// const ignorefilePath = Util.makeUnixPath("akashic-cli-commons/node_modules/process/browser.js");
 				const ignoreModulePaths = [
-					"akashic-cli-commons/node_modules/"
+					"akashic-cli-commons/node_modules/process/"
 					].map((modulePath) => Util.makeUnixPath(modulePath));
-				// console.log(rawFilePath, ignorefilePath);
-				// if (rawFilePath.includes(ignorefilePath)) return;
-				if (ignoreModulePaths.find((modulePath) => rawFilePath.includes(modulePath))) {
-					return;
-				}
+				if (ignoreModulePaths.find((modulePath) => rawFilePath.includes(modulePath))) return;
 
 				var filePath = Util.makeUnixPath(path.relative(basepath, row.file));
 				if (/^\.\.\//.test(filePath)) {
-					console.log("[BAD]", filePath);
-					//return ;
 					var msg = "Unsupported module found in " + JSON.stringify(modules)
 												+ ". Skipped to listing '" + filePath
 												+ "' that cannot be dealt with. (This may be a core module of Node.js)";
@@ -76,7 +68,6 @@ export module NodeModules {
 				filePaths.push(filePath);
 			});
 			b.bundle((err: any) => {
-				console.log("bundle err", !!err);
 				err ? reject(err) : resolve(filePaths);
 			});
 		});

--- a/src/NodeModules.ts
+++ b/src/NodeModules.ts
@@ -69,7 +69,7 @@ export module NodeModules {
 						const msg = "Reference to '" + detectedModuleName
 							+ "' is detected, and Skipped to listing."
 							+ " Akashic content should not depend on core module of Node.js."
-							+ " Game Developers should build your game without reference to '" + detectedModuleName + "'.";
+							+ " Game Developers should build your game runnable without reference to '" + detectedModuleName + "'.";
 						logger.warn(msg);
 						return;
 					}


### PR DESCRIPTION
## このpull equestが解決する内容
akashicコンテンツのdependenciesにbabel-polyfill が含まれている状態で `akashic scan globalScripts` を利用したときに発生する挙動不良を解決します。

babel-polyfillは内部的に Node.processを呼び出しており、 globalScriptsが探索するrequireチェーンにNode.processを含んでしまいます。


## 破壊的な変更を含んでいるか?
なし