### PR TITLE
Support filename as an argument of NodeModules#listModuleFiles() 

### DIFF
--- a/src/GameConfiguration.ts
+++ b/src/GameConfiguration.ts
@@ -45,6 +45,7 @@ export interface GameConfiguration {
 	width: number;
 	height: number;
 	fps?: number;
+	main?: string;
 	audio?: {[key: string]: AudioSystemConfiguration};
 	assets?: Assets;
 	globalScripts?: string[];

--- a/src/NodeModules.ts
+++ b/src/NodeModules.ts
@@ -23,7 +23,7 @@ export module NodeModules {
 		var packageJsonPaths: string[] = [];
 		var alreadyProcessed: { [path: string]: boolean } = {};
 		packageDirPaths.forEach((dirPath: string) => {
-			if (!dirPath || alreadyProcessed[dirPath])
+			if (alreadyProcessed[dirPath])
 				return;
 			alreadyProcessed[dirPath] = true;
 

--- a/src/NodeModules.ts
+++ b/src/NodeModules.ts
@@ -15,14 +15,13 @@ export module NodeModules {
 	}
 
 	export function _listPackageJsonsFromScriptsPath(basepath: string, filepaths: string[]): string[] {
-		var packageDirPaths: string[] =	filepaths.map((path) => {
-			var m = /(.*node_modules\/(?:@.*?\/)?(?:.*?)\/)/.exec(path);
-			return m && m[1];
-		});
-
 		var packageJsonPaths: string[] = [];
 		var alreadyProcessed: { [path: string]: boolean } = {};
-		packageDirPaths.forEach((dirPath: string) => {
+		filepaths.forEach((filepath: string) => {
+			var m = /(.*node_modules\/(?:@.*?\/)?(?:.*?)\/)/.exec(filepath);
+			if (!m)
+				return;
+			var dirPath = m[1];
 			if (alreadyProcessed[dirPath])
 				return;
 			alreadyProcessed[dirPath] = true;


### PR DESCRIPTION
## このpull requestが解決する内容

akashic-cli-scan の拡張にあたり、 `NodeModules#listModuleFile()` を (モジュール名からではなく) スクリプトアセットのファイル名から行えるようにします。

## 破壊的な変更を含んでいるか?

なし