### PR TITLE
Rename some methods to be used by external modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.3
+* `NodeModules#_listPackageJsonsFromScriptsPath()` を `NodeModules#listPackageJsonsFromScriptsPath()` に変更
+* `NodeModules#_listScriptFiles()` を `NodeModules#listScriptFiles()` に変更
+
 ## 0.2.2
 
 * game.json に environment メンバを追加

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.3
 * `NodeModules#_listPackageJsonsFromScriptsPath()` を `NodeModules#listPackageJsonsFromScriptsPath()` に変更
 * `NodeModules#_listScriptFiles()` を `NodeModules#listScriptFiles()` に変更
+* `GameConfiguration#ModuleMainScripts` を追加
 
 ## 0.2.2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-cli-commons",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "The shared definitions and routines for akashic-cli-xxx",
   "main": "lib/index.js",
   "scripts": {

--- a/spec/NodeModulesSpec.js
+++ b/spec/NodeModulesSpec.js
@@ -69,20 +69,20 @@ describe("NodeModules", function () {
 		});
 	});
 
-	describe("._listPackageJsonsFromScriptsPath()", function () {
+	describe(".listPackageJsonsFromScriptsPath()", function () {
 		it("list the files named package.json", function (done) {
 			mockfs(mockFsContent);
 			Promise.resolve()
-				.then(() => NodeModules._listScriptFiles(".", ["dummy", "dummy2"]))
-				.then((filePaths) => NodeModules._listPackageJsonsFromScriptsPath(".", filePaths))
+				.then(() => NodeModules.listScriptFiles(".", ["dummy", "dummy2"]))
+				.then((filePaths) => NodeModules.listPackageJsonsFromScriptsPath(".", filePaths))
 				.then((pkgJsonPaths) => {
 					expect(pkgJsonPaths.sort((a, b) => ((a > b) ? 1 : (a < b) ? -1 : 0))).toEqual([
 						"node_modules/dummy/package.json",
 						"node_modules/dummy/node_modules/dummyChild/package.json"
 					].sort((a, b) => ((a > b) ? 1 : (a < b) ? -1 : 0)))
 				})
-				.then(() => NodeModules._listScriptFiles(".", "dummy2"))
-				.then((filePaths) => NodeModules._listPackageJsonsFromScriptsPath(".", filePaths))
+				.then(() => NodeModules.listScriptFiles(".", "dummy2"))
+				.then((filePaths) => NodeModules.listPackageJsonsFromScriptsPath(".", filePaths))
 				.then((pkgJsonPaths) => {
 					expect(pkgJsonPaths).toEqual([]);
 				})
@@ -91,11 +91,11 @@ describe("NodeModules", function () {
 		});
 	});
 
-	describe("._listScriptFiles()", function () {
+	describe(".listScriptFiles()", function () {
 		it("list the scripts in node_modules/ up", function (done) {
 			mockfs(mockFsContent);
 			Promise.resolve()
-				.then(() => NodeModules._listScriptFiles(".", ["dummy", "dummy2"]))
+				.then(() => NodeModules.listScriptFiles(".", ["dummy", "dummy2"]))
 				.then((filePaths) => {
 					expect(filePaths.sort((a, b) => ((a > b) ? 1 : (a < b) ? -1 : 0))).toEqual([
 						"node_modules/dummy/foo.js",
@@ -105,7 +105,7 @@ describe("NodeModules", function () {
 						"node_modules/dummy2/sub.js"
 					]);
 				})
-				.then(() => NodeModules._listScriptFiles(".", "dummy"))
+				.then(() => NodeModules.listScriptFiles(".", "dummy"))
 				.then((filePaths) => {
 					expect(filePaths.sort((a, b) => ((a > b) ? 1 : (a < b) ? -1 : 0))).toEqual([
 						"node_modules/dummy/foo.js",
@@ -119,7 +119,7 @@ describe("NodeModules", function () {
 	});
 
 	// モジュール名に node_modules を含むモジュールに依存しているケース
-	describe("._listPackageJsonsFromScriptsPath() with failure-prone module name", function () {
+	describe(".listPackageJsonsFromScriptsPath() with failure-prone module name", function () {
 		it("list the files named package.json", function (done) {
 			mockFsContent = {
 				"node_modules": {
@@ -175,8 +175,8 @@ describe("NodeModules", function () {
 			};
 			mockfs(mockFsContent);
 			Promise.resolve()
-				.then(() => NodeModules._listScriptFiles(".", ["@dummy/dummy_node_modules", "dummy_node_modules"]))
-				.then((filePaths) => NodeModules._listPackageJsonsFromScriptsPath(".", filePaths))
+				.then(() => NodeModules.listScriptFiles(".", ["@dummy/dummy_node_modules", "dummy_node_modules"]))
+				.then((filePaths) => NodeModules.listPackageJsonsFromScriptsPath(".", filePaths))
 				.then((pkgJsonPaths) => {
 					expect(pkgJsonPaths.sort((a, b) => ((a > b) ? 1 : (a < b) ? -1 : 0))).toEqual([
 						"node_modules/@dummy/dummy_node_modules/package.json",

--- a/src/GameConfiguration.ts
+++ b/src/GameConfiguration.ts
@@ -38,6 +38,8 @@ export interface OperationPluginDeclaration {
 	option?: any;
 }
 
+export type ModuleMainScripts = { [path: string]: string };
+
 /**
  * game.json の型。
  */
@@ -51,6 +53,7 @@ export interface GameConfiguration {
 	globalScripts?: string[];
 	operationPlugins?: OperationPluginDeclaration[];
 	environment?: ModuleEnvironment;
+	moduleMainScripts?: ModuleMainScripts;
 }
 
 

--- a/src/NodeModules.ts
+++ b/src/NodeModules.ts
@@ -10,11 +10,11 @@ export module NodeModules {
 	export function listModuleFiles(basepath: string, modules: string|string[], logger: Logger = new ConsoleLogger()): Promise<string[]> {
 		if (modules.length === 0) return Promise.resolve([]);
 		return Promise.resolve()
-			.then(() => NodeModules._listScriptFiles(basepath, modules, logger))
-			.then((paths) => paths.concat(NodeModules._listPackageJsonsFromScriptsPath(basepath, paths)));
+			.then(() => NodeModules.listScriptFiles(basepath, modules, logger))
+			.then((paths) => paths.concat(NodeModules.listPackageJsonsFromScriptsPath(basepath, paths)));
 	}
 
-	export function _listPackageJsonsFromScriptsPath(basepath: string, filepaths: string[]): string[] {
+	export function listPackageJsonsFromScriptsPath(basepath: string, filepaths: string[]): string[] {
 		var packageJsonPaths: string[] = [];
 		var alreadyProcessed: { [path: string]: boolean } = {};
 		filepaths.forEach((filepath: string) => {
@@ -35,7 +35,7 @@ export module NodeModules {
 		return packageJsonPaths;
 	}
 
-	export function _listScriptFiles(basepath: string, modules: string|string[], logger: Logger): Promise<string[]> {
+	export function listScriptFiles(basepath: string, modules: string|string[], logger: Logger): Promise<string[]> {
 		var moduleNames = (typeof modules === "string") ? [modules] : modules;
 
 		// moduleNamesをrequireするだけのソースコード文字列を作って依存性解析の基点にする

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,10 @@ import { ConfigurationFile } from "./ConfigurationFile";
 export { ConfigurationFile };
 import { Configuration, ConfigurationParameterObject } from "./Configuration";
 export { Configuration, ConfigurationParameterObject };
-import { AssetConfiguration, AudioSystemConfiguration, Assets, OperationPluginDeclaration, GameConfiguration } from "./GameConfiguration";
-export { AssetConfiguration, AudioSystemConfiguration, Assets, OperationPluginDeclaration, GameConfiguration };
+import {
+	AssetConfiguration, AudioSystemConfiguration, Assets, OperationPluginDeclaration, GameConfiguration, ModuleMainScripts
+} from "./GameConfiguration";
+export { AssetConfiguration, AudioSystemConfiguration, Assets, OperationPluginDeclaration, GameConfiguration, ModuleMainScripts };
 /* tslint:disable */  // tslintがUtilをunused variableとして誤検出するので無効化
 import * as Util from "./Util";
 export { Util };


### PR DESCRIPTION
## このPullRequestが解決する内容
`NodeModules` のメソッドを外部モジュールから参照可能にします。
（これらのメソッドはexport指定されているため以前から参照可能でしたが、 `_` 付きのものは内部モジュールやテストでのみの参照を想定しているため `_` を除いています。）