### PR TITLE
avoid wrong renaming of moduleMainScripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.2.9
+* `Renamer` がgame.jsonの `moduleMainScripts` のファイル名をハッシュ化してしまう問題を修正
+
 ## 0.2.8
 * game.json のハッシュ化処理が誤っていた問題を修正
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-cli-commons",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "The shared definitions and routines for akashic-cli-xxx",
   "main": "lib/index.js",
   "scripts": {

--- a/spec/RenamerSpec.js
+++ b/spec/RenamerSpec.js
@@ -108,7 +108,8 @@ describe("Renamer", function () {
 					virtualPath: "node_modules/foo/bar/index.js",
 					global: true
 				});
-				expect(gamejson.moduleMainScripts["foo"]).toBe(Renamer.hashBasename("node_modules/foo/bar/index.js", 20));
+				// moduleMainScripts はvirtualPathで扱うのでリネームされていてはならない
+				expect(gamejson.moduleMainScripts["foo"]).toBe("node_modules/foo/bar/index.js");
 				expect(fs.statSync(path.join("srcDir", "image/a70844aefe0a5ceb64eb.png")).isFile()).toBe(true);
 				expect(fs.statSync(path.join("srcDir", "script/04ef22b752657e08b66f.js")).isFile()).toBe(true);
 				expect(fs.statSync(path.join("srcDir", "audio/47acba638f0bcfc681d7.mp4")).isFile()).toBe(true);

--- a/src/Renamer.ts
+++ b/src/Renamer.ts
@@ -26,7 +26,6 @@ export function hashBasename(filepath: string, nameLength: number): string {
 export function renameAssetFilenames(content: GameConfiguration, basedir: string, maxHashLength: number = 20): void {
 	_renameAssets(content, basedir, maxHashLength);
 	_renameGlobalScripts(content, basedir, maxHashLength);
-	_renameModuleMainScripts(content, basedir, maxHashLength);
 }
 
 /**
@@ -91,13 +90,4 @@ function _renameGlobalScripts(content: GameConfiguration, basedir: string, maxHa
 		});
 	}
 	content.globalScripts = [];
-}
-
-function _renameModuleMainScripts(content: GameConfiguration, basedir: string, maxHashLength: number) {
-	if (content.moduleMainScripts) {
-		Object.keys(content.moduleMainScripts).forEach((name: string) => {
-			content.moduleMainScripts[name] = hashBasename(content.moduleMainScripts[name], maxHashLength);
-			// moduleMainScripts は globalScripts として登録されているためファイルのリネームはしない
-		});
-	}
 }


### PR DESCRIPTION
掲題どおり。

https://github.com/akashic-games/akashic-engine/pull/54 (moduleMainScripts の解決に virtualPath でなく assetId を使っている) と複合的な問題で、 ハッシュ化した場合の moduleMainScripts が正しく動作していませんでした。

moduleMainScripts の値は従来ハッシュ化されたファイル名 (pathに相当) になっていますが、ハッシュ化前のパス (virtualPathに相当) でなければならないはずで、これを修正します。


| | 非ハッシュ化 | ハッシュ化 |
|:---|:---:|:---:|
| AE修正前(assetIdから引く) + 本PR前(pathを書き込む) | ○ | × |
| AE修正前(assetIdから引く) + 本PR後(virtualPathを書き込む) | ○ | × |
| AE修正後(virtualPathから引く) + 本PR前(pathを書き込む) | ○ | × |
| AE修正後(virtualPathから引く) + 本PR前(virtualPathを書き込む) | ○ | ○ |

- ハッシュ化していない場合、 globalScripts のファイルは assetId = path = virtualPath
  -  → AEの修正に関わらず動く
- ハッシュ化した場合、 globalScripts のファイルは assetId ≠ path ≠ virtualPath
  -  → AE修正後かつ本PR後でないと動かない
