### PR TITLE
Update travis.yml for node v10 error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ node_js:
 - 6
 - 8
 - 10.4
-# mock-fsが node v10.5以上で、fs.promiseのcallbackが動作しないため、暫定として10.4を指定
+# mock-fsがnode v10.5以上で、fs.promiseのcallbackが動作しないため、暫定として10.4を指定

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ language: node_js
 node_js:
 - 6
 - 8
-- 10
+- 10.4
+# mock-fsが node v10.5以上で、fs.promiseのcallbackが動作しないため、暫定として10.4を指定

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "remark-cli": "~2.0.0",
     "remark-lint": "~5.0.1",
     "mdast-lint": "~1.1.1",
-    "mock-fs": "~4.7.0",
+    "mock-fs": "~4.5.0",
     "tslint": "~5.4.3",
     "typescript": "~2.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "remark-cli": "~2.0.0",
     "remark-lint": "~5.0.1",
     "mdast-lint": "~1.1.1",
-    "mock-fs": "~4.5.0",
+    "mock-fs": "~4.7.0",
     "tslint": "~5.4.3",
     "typescript": "~2.6.1"
   },


### PR DESCRIPTION
## このpull requestが解決する内容

TravisCIのnode v10でエラーとなる問題の修正
  - .travis.yml のnodeのv10系の指定を10.4へ修正
     - mock-fsにてnode v10.5以上の場合、fs.Promiseのcallbackが動作しない問題があるため

ロジック自体には影響がないため、セルフマージとする。