### PR TITLE
fix filepath conflict

### DIFF
--- a/spec/RenamerSpec.js
+++ b/spec/RenamerSpec.js
@@ -120,6 +120,45 @@ describe("Renamer", function () {
 			.catch(done.fail)
 		});
 
+		// アセットの path が重複している場合、重複するアセットでハッシュ化後のファイルを共有する
+		it("hash game.json - throw error", function (done) {
+			Promise.resolve()
+			.then(() => ConfigurationFile.ConfigurationFile.read(path.join("./srcDir", "game.json"), undefined))
+			.then((gamejson) => {
+				gamejson.assets = {
+					hoge: {
+						type: "image",
+						path: "image/hoge.png",
+						global: true
+					},
+					hoge2: {
+						type: "image",
+						path: "image/hoge.png",
+						global: true
+					}
+				};
+				gamejson.globalScripts = [];
+				expect(() => {
+					Renamer.renameAssetFilenames(gamejson, "./srcDir");
+					expect(fs.statSync(path.join("srcDir", "files/04ef22b752657e08b66f.js")).isFile()).toBe(true);
+					expect(gamejson.assets["hoge"]).toEqual({
+						type: "image",
+						path: "files/a70844aefe0a5ceb64eb.png",
+						virtualPath: "image/hoge.png",
+						global: true
+					});
+					expect(gamejson.assets["hoge2"]).toEqual({
+						type: "image",
+						path: "files/a70844aefe0a5ceb64eb.png",
+						virtualPath: "image/hoge.png",
+						global: true
+					});
+
+				});
+				done();
+			})
+			.catch(done.fail);
+		});
 	});
 	describe("renameAssetFilenames()", function () {
 		var content = {

--- a/spec/RenamerSpec.js
+++ b/spec/RenamerSpec.js
@@ -120,29 +120,6 @@ describe("Renamer", function () {
 			.catch(done.fail)
 		});
 
-		// アセットの path が重複している場合、ファイル名の衝突が発生しエラーになる
-		it("hash game.json - throw error", function (done) {
-			Promise.resolve()
-			.then(() => ConfigurationFile.ConfigurationFile.read(path.join("./srcDir", "game.json"), undefined))
-			.then((gamejson) => {
-				gamejson.assets = {
-					hoge: {
-						type: "image",
-						path: "image/hoge.png",
-						global: true
-					},
-					hoge2: {
-						type: "image",
-						path: "image/hoge.png",
-						global: true
-					}
-				};
-				gamejson.globalScripts = [];
-				expect(() => {Renamer.renameAssetFilenames(gamejson, "./srcDir")}).toThrow(new Error(Renamer.ERROR_FILENAME_CONFLICT));
-				done();
-			})
-			.catch(done.fail);
-		});
 	});
 	describe("renameAssetFilenames()", function () {
 		var content = {

--- a/src/Renamer.ts
+++ b/src/Renamer.ts
@@ -86,16 +86,6 @@ function _renameAssets(content: GameConfiguration, basedir: string, maxHashLengt
 	_removeDirectoryIfEmpty(assetAncestorDirs, basedir);
 }
 
-function isRenamed(content: GameConfiguration, hashedFilePath: string) {
-	const paths: string[] = [];
-	const assetNames = Object.keys(content.assets);
-	assetNames.forEach((name) => {
-		paths.push(content.assets[name].path);
-	});
-	if (paths.indexOf(hashedFilePath) !== -1) return true; // 重複あり
-	return false;
-}
-
 function _renameGlobalScripts(content: GameConfiguration, processedAssetPaths: Set<string>, basedir: string, maxHashLength: number): void {
 	if (content.globalScripts) {
 		content.globalScripts.forEach((name: string, idx: number) => {

--- a/src/Renamer.ts
+++ b/src/Renamer.ts
@@ -25,8 +25,9 @@ export function hashFilepath(filepath: string, nameLength: number): string {
  * @param maxHashLength ハッシュ化後のファイル名の文字数の最大値。省略された場合、20文字
  */
 export function renameAssetFilenames(content: GameConfiguration, basedir: string, maxHashLength: number = 20): void {
-	_renameAssets(content, basedir, maxHashLength);
-	_renameGlobalScripts(content, basedir, maxHashLength);
+	const processedAssetPaths: Set<string> = new Set();
+	_renameAssets(content, basedir, maxHashLength, processedAssetPaths);
+	_renameGlobalScripts(content, processedAssetPaths, basedir, maxHashLength);
 }
 
 /**
@@ -35,7 +36,7 @@ export function renameAssetFilenames(content: GameConfiguration, basedir: string
  * @param filePath リネームするファイルのパス
  * @param newFilePath リネームされたファイルのパス
  */
-function _renameFilename(basedir: string, filePath: string, newFilePath: string): void {
+function _renameFilename(basedir: string, filePath: string, newFilePath: string, processedAssetPaths: Set<string>): void {
 	try {
 		fs.accessSync(path.resolve(basedir, newFilePath));
 	} catch (error) {
@@ -49,12 +50,12 @@ function _renameFilename(basedir: string, filePath: string, newFilePath: string)
 	throw new Error(ERROR_FILENAME_CONFLICT);
 }
 
-function _renameAudioFilename(basedir: string, filePath: string, newFilePath: string): void {
+function _renameAudioFilename(basedir: string, filePath: string, newFilePath: string, processedAssetPaths: Set<string>): void {
 	const extTypes = [".ogg", ".aac", ".mp4"];
 	extTypes.forEach((ext) => {
 		try {
 			fs.accessSync(path.resolve(basedir, filePath + ext));
-			_renameFilename(basedir, filePath + ext, newFilePath + ext);
+			_renameFilename(basedir, filePath + ext, newFilePath + ext, processedAssetPaths);
 		} catch (error) {
 			if (error.code === "ENOENT") return; // 全てのオーディオ拡張子が揃っているとは限らない
 			throw error;
@@ -62,22 +63,23 @@ function _renameAudioFilename(basedir: string, filePath: string, newFilePath: st
 	});
 }
 
-function _renameAssets(content: GameConfiguration, basedir: string, maxHashLength: number): void {
+function _renameAssets(content: GameConfiguration, basedir: string, maxHashLength: number, processedAssetPaths: Set<string>): void {
 	const assetNames = Object.keys(content.assets);
 	const dirpaths: string[] = [];
 	assetNames.forEach((name) => {
 		const filePath = content.assets[name].path;
 		dirpaths.push(path.dirname(filePath));
 		const hashedFilePath = hashFilepath(filePath, maxHashLength);
-		const isRenamedAsset = isRenamed(content, hashedFilePath);
+		const isRenamedAsset = processedAssetPaths.has(hashedFilePath);
 
 		content.assets[name].path = hashedFilePath;
 		content.assets[name].virtualPath = filePath;
+		processedAssetPaths.add(hashedFilePath);
 		if (isRenamedAsset) return; // 同じパスのアセットを既にハッシュ化済みの場合、ファイルはリネーム済み
 		if (content.assets[name].type !== "audio") {
-			_renameFilename(basedir, filePath, hashedFilePath);
+			_renameFilename(basedir, filePath, hashedFilePath, processedAssetPaths);
 		} else {
-			_renameAudioFilename(basedir, filePath, hashedFilePath);
+			_renameAudioFilename(basedir, filePath, hashedFilePath, processedAssetPaths);
 		}
 	});
 	const assetAncestorDirs = _listAncestorDirNames(dirpaths);
@@ -94,7 +96,7 @@ function isRenamed(content: GameConfiguration, hashedFilePath: string) {
 	return false;
 }
 
-function _renameGlobalScripts(content: GameConfiguration, basedir: string, maxHashLength: number): void {
+function _renameGlobalScripts(content: GameConfiguration, processedAssetPaths: Set<string>, basedir: string, maxHashLength: number): void {
 	if (content.globalScripts) {
 		content.globalScripts.forEach((name: string, idx: number) => {
 			const assetname = "a_e_z_" + idx;
@@ -107,7 +109,7 @@ function _renameGlobalScripts(content: GameConfiguration, basedir: string, maxHa
 				global: true
 			};
 			if (isRenamedAsset) return; // 同じパスのアセットを既にハッシュ化済みの場合、ファイルはリネーム済み
-			_renameFilename(basedir, name, hashedFilePath);
+			_renameFilename(basedir, name, hashedFilePath, processedAssetPaths);
 		});
 
 		const assetDirs = _listAncestorDirNames(content.globalScripts.map((filepath) => path.dirname(filepath)));

--- a/src/Renamer.ts
+++ b/src/Renamer.ts
@@ -92,7 +92,6 @@ function isRenamed(content: GameConfiguration, hashedFilePath: string) {
 	});
 	if (paths.indexOf(hashedFilePath) !== -1) return true; // 重複あり
 	return false;
-
 }
 
 function _renameGlobalScripts(content: GameConfiguration, basedir: string, maxHashLength: number): void {

--- a/src/Renamer.ts
+++ b/src/Renamer.ts
@@ -101,13 +101,15 @@ function _renameGlobalScripts(content: GameConfiguration, processedAssetPaths: S
 		content.globalScripts.forEach((name: string, idx: number) => {
 			const assetname = "a_e_z_" + idx;
 			const hashedFilePath = hashFilepath(name, maxHashLength);
-			const isRenamedAsset = isRenamed(content, hashedFilePath);
+			const isRenamedAsset = processedAssetPaths.has(hashedFilePath);
+
 			content.assets[assetname] = {
 				type: /\.json$/i.test(name) ? "text" : "script",
 				virtualPath: name,
 				path: hashedFilePath,
 				global: true
 			};
+			processedAssetPaths.add(hashedFilePath);
 			if (isRenamedAsset) return; // 同じパスのアセットを既にハッシュ化済みの場合、ファイルはリネーム済み
 			_renameFilename(basedir, name, hashedFilePath, processedAssetPaths);
 		});


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
複数のアセットが同じパスを参照するコンテンツに対して、 `akashic export zip --hash-filename` すると失敗する問題を修正します。

### 概要

akashicコンテンツにおけるgame.jsonは、その仕様上、同じアセットファイルに対して、複数の異なるアセットIDを割り当てることができます。
これは `akashic scan` コマンドを利用せず、直接game.jsonを書き換えた場合に起こります。

このようなコンテンツは正常に動作しますが、 `akashic export zip --hash-filename` によってファイル名をハッシュ化する際、ハッシュ化処理の重複が発生し、ファイル名コンフリクトによってエラーが発生していました。

本PRでは、このような場合に、ハッシュ化処理をスキップすることで、エラーを回避します。


## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

